### PR TITLE
Use {ModuleName}.h for the generated umbrella header. 

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -132,6 +132,11 @@ def _write_umbrella_header(
         module_name = None,
         **kwargs):
     basename = "{name}.h".format(name = name)
+    if sets.contains([paths.basename(h) for h in public_headers], basename):
+        # If MyModule.h already exists in the public_headers,
+        # we will generate MyModule-umbrella.h instead.
+        basename = "{name}-umbrella.h".format(name = name)
+
     destination = paths.join(name + "-modulemap", basename)
     if not module_name:
         module_name = name

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -132,7 +132,7 @@ def _write_umbrella_header(
         module_name = None,
         **kwargs):
     basename = "{name}.h".format(name = name)
-    if sets.contains([paths.basename(h) for h in public_headers], basename):
+    if len([h for h in public_headers if paths.basename(h) == basename]) > 0:
         # If MyModule.h already exists in the public_headers,
         # we will generate MyModule-umbrella.h instead.
         basename = "{name}-umbrella.h".format(name = name)

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -131,7 +131,7 @@ def _write_umbrella_header(
         private_headers = [],
         module_name = None,
         **kwargs):
-    basename = "{name}-umbrella.h".format(name = name)
+    basename = "{name}.h".format(name = name)
     destination = paths.join(name + "-modulemap", basename)
     if not module_name:
         module_name = name


### PR DESCRIPTION
Currently when generating an umbrella header, we use `MyModule-umbrella.h` as the file name. However, the Swift compiler expects the header file to be `MyModule.h`.

This PR changes the generated header file to be `MyModule.h` unless `MyModule.h` already exists in the public header list.

This attempts to address [this issue](https://github.com/bazel-ios/rules_ios/issues/349).