### PR TITLE
Fix the problem that `includes` of `objc_library` won't be propagated to transitive `apple_framework` deps 

### DIFF
--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -854,6 +854,10 @@ def _apple_framework_packaging_impl(ctx):
         direct = [],
         transitive = [getattr(dep[CcInfo].compilation_context, "defines") for dep in deps if CcInfo in dep],
     ))
+    objc_provider_utils.add_to_dict_if_present(compilation_context_fields, "includes", depset(
+        direct = [],
+        transitive = [getattr(dep[CcInfo].compilation_context, "includes") for dep in deps if CcInfo in dep],
+    ))
 
     # Compute cc_info and swift_info
     virtualize_frameworks = feature_names.virtualize_frameworks in ctx.features


### PR DESCRIPTION
This PR fixes an issue that is described [here](https://github.com/qyang-nj/BazelPlayground/tree/main/Issue1).